### PR TITLE
use process.platform to check for Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
 var spawn = require('child_process').spawn
 var os = require('os')
 var Through = require('audio-through')
-var os = require('os')
 
-if (os.type() == 'Darwin' || os.type().indexOf('Windows') > -1) {
+if (process.platform !== 'linux') {
   throw new Error('Only linux is supported with Node -- alas! Please file a PR!')
 }
 


### PR DESCRIPTION
This is also a safer positive check than the negative check that was in place before.